### PR TITLE
getting rid of capitalization

### DIFF
--- a/ssb-interop.js
+++ b/ssb-interop.js
@@ -128,7 +128,6 @@ div.c-message.c-message--light.c-message--hover {
 }
 .c-message__sender a {
     font-weight: 600;
-    text-transform: capitalize;
     color: white !important;
     font-size: 15px !important;
 }
@@ -515,7 +514,6 @@ p-search_filter__date:first-child {
 }
 .light_theme ts-message .message_content .message_sender {
     color:  #a4d677 !important;
-    text-transform: capitalize;
     font-weight: 700 !important;
 }
 .p-channel_sidebar__channel--unread:not(.p-channel_sidebar__channel--muted) .p-channel_sidebar__name {


### PR DESCRIPTION
The current slack-black-theme (which is great) capitalizes usernames for some reason with two "text-transform: capitalize". This seems unnecessary (considering Slack doesn't do it) and (to me) doesn't look great imo. This PR gets rid of that capitalization.

Thanks for the dark mode theme, it's great!