### PR TITLE
Fix invisible close button in thread sidebar

### DIFF
--- a/ssb-interop.js
+++ b/ssb-interop.js
@@ -1105,6 +1105,9 @@ color:#a4d677 !important
                                 .p-threads_flexpane__header .p-flexpane_header__children{
                                     font-weight:700;
                                 }
+                                .p-threads_flexpane__header button[aria-label="Close Right Sidebar"] {
+                                    color: #949494;
+                                }
                                 .p-threads_view__default_background--first{
                                     background:#323232 !important;
                                 }


### PR DESCRIPTION
When opening a thread, the sidebar's close button is invisible. It seems like it's default color matches the color of the thread background itself. This makes it's color match that of the other sidebars e.g. the channel info sidebar.