### PR TITLE
remove reference to nonexistent variable in JS

### DIFF
--- a/slack-dark-mode.sh
+++ b/slack-dark-mode.sh
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', function() {
   cssPromise.then((css) => {
     let s = document.createElement('style');
     s.type = 'text/css';
-    s.innerHTML = css + customCustomCSS;
+    s.innerHTML = css;
     document.head.appendChild(s);
   });
 });"


### PR DESCRIPTION
This was failing to work as expected before this change.