### PR TITLE
Fix black text in member details popup + member details side pane

### DIFF
--- a/slack-dark-mode.css
+++ b/slack-dark-mode.css
@@ -2555,7 +2555,6 @@ span.c-message__body, a.c-message__sender_link, span.c-message_attachment__media
     padding: 0 24px;
     text-align: center;
     color: white !important;}
-    
     .p-pinned_items__empty_list .p-pinned_items__empty_list_action {
     color: #ffb672 !important;}
     .p-channel_details_section {
@@ -2569,6 +2568,6 @@ span.c-message__body, a.c-message__sender_link, span.c-message_attachment__media
     color: white;}
     .p-channel_details__dm_section__tz_label {
     color: rgba(255, 255, 255, 0.7);}
-    .p-member_profile_card {
+    .p-member_profile_card, .p-member_profile_field__label, p-member_profile_field__value {
     box-shadow: 0 0 0 1px rgba(0,0,0,.08), 0 4px 12px 0 rgba(0,0,0,.08);
     background: #333;}


### PR DESCRIPTION
This fixes the black text on black background fields in:
- The member details popup (when you click a member's picture)
- The member details pane (pane appearing on the right-hand side when you click the member's name from the member details popup