### PR TITLE
More fix to member profile pane - add white text

### DIFF
--- a/slack-dark-mode.css
+++ b/slack-dark-mode.css
@@ -2570,4 +2570,5 @@ span.c-message__body, a.c-message__sender_link, span.c-message_attachment__media
     color: rgba(255, 255, 255, 0.7);}
     .p-member_profile_card, .p-member_profile_field__label, p-member_profile_field__value {
     box-shadow: 0 0 0 1px rgba(0,0,0,.08), 0 4px 12px 0 rgba(0,0,0,.08);
+    color: white !important;
     background: #333;}


### PR DESCRIPTION
Sorry, my last PR (https://github.com/caiceA/slack-black-theme/pull/120/files) wasn't including all the fix.
Not sure how I saw it working, but this morning the text was back to black.
So this PR is explicitly setting the text to white in the member profile popup + pane.